### PR TITLE
chore(deps-dev): bump vue and vue-template-compiler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2707,17 +2707,10 @@
       }
     },
     "@elastic/apm-rum": {
-      "version": "file:packages/rum",
-      "requires": {
-        "@elastic/apm-rum-core": "file:packages/rum-core"
-      }
+      "version": "file:packages/rum"
     },
     "@elastic/apm-rum-angular": {
-      "version": "file:packages/rum-angular",
-      "requires": {
-        "@elastic/apm-rum": "file:packages/rum",
-        "@elastic/apm-rum-core": "file:packages/rum-core"
-      }
+      "version": "file:packages/rum-angular"
     },
     "@elastic/apm-rum-core": {
       "version": "file:packages/rum-core",
@@ -2730,7 +2723,6 @@
     "@elastic/apm-rum-react": {
       "version": "file:packages/rum-react",
       "requires": {
-        "@elastic/apm-rum": "file:packages/rum",
         "hoist-non-react-statics": "^3.3.0"
       },
       "dependencies": {
@@ -2745,11 +2737,7 @@
       }
     },
     "@elastic/apm-rum-vue": {
-      "version": "file:packages/rum-vue",
-      "requires": {
-        "@elastic/apm-rum": "file:packages/rum",
-        "@elastic/apm-rum-core": "file:packages/rum-core"
-      }
+      "version": "file:packages/rum-vue"
     },
     "@evocateur/libnpmaccess": {
       "version": "3.1.2",
@@ -21322,9 +21310,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
-      "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
+      "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ==",
       "dev": true
     },
     "vue-hot-reload-api": {
@@ -21363,9 +21351,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.10.tgz",
-      "integrity": "sha512-jVZkw4/I/HT5ZMvRnhv78okGusqe0+qH2A0Em0Cp8aq78+NK9TII263CDVz2QXZsIT+yyV/gZc/j/vlwa+Epyg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.11.tgz",
+      "integrity": "sha512-KIq15bvQDrcCjpGjrAhx4mUlyyHfdmTaoNfeoATHLAiWB+MU3cx4lOzMwrnUh9cCxy0Lt1T11hAFY6TQgroUAA==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",


### PR DESCRIPTION
Bumps [vue](https://github.com/vuejs/vue) and [vue-template-compiler](https://github.com/vuejs/vue). These dependencies needed to be updated together.

Updates `vue` from 2.6.10 to 2.6.11
<details>
<summary>Release notes</summary>

*Sourced from [vue's releases](https://github.com/vuejs/vue/releases).*

> ## v2.6.11
> ### Security Fixes
> 
> - Bump `vue-server-renderer`'s dependency of `serialize-javascript` to 2.1.2
> 
> ### Bug Fixes
> 
> * **types:** fix prop constructor type inference ([#10779](https://github-redirect.dependabot.com/vuejs/vue/issues/10779)) 4821149, closes [#10779](https://github-redirect.dependabot.com/vuejs/vue/issues/10779)
> * fix function expression regex ([#9922](https://github-redirect.dependabot.com/vuejs/vue/issues/9922)) 569b728, closes [#9922](https://github-redirect.dependabot.com/vuejs/vue/issues/9922) [#9920](https://github-redirect.dependabot.com/vuejs/vue/issues/9920)
> * **compiler:** Remove the warning for valid v-slot value ([#9917](https://github-redirect.dependabot.com/vuejs/vue/issues/9917)) 085d188, closes [#9917](https://github-redirect.dependabot.com/vuejs/vue/issues/9917)
> * **types:** fix global namespace declaration for UMD bundle ([#9912](https://github-redirect.dependabot.com/vuejs/vue/issues/9912)) ab50e8e, closes [#9912](https://github-redirect.dependabot.com/vuejs/vue/issues/9912)
</details>
<details>
<summary>Commits</summary>

- [`ec78fc8`](https://github.com/vuejs/vue/commit/ec78fc8b6d03e59da669be1adf4b4b5abf670a34) build: release 2.6.11
- [`a98048f`](https://github.com/vuejs/vue/commit/a98048fa67bb686eced6eacec156caccd33b8676) build: build 2.6.11
- [`fc41f91`](https://github.com/vuejs/vue/commit/fc41f913124b4c9cfdc9670392009774c7fc85ad) chore: update yarn.lock
- [`70429c3`](https://github.com/vuejs/vue/commit/70429c3713a497c0659fb67d61b000a3125325d2) build(deps-dev): bump serialize-javascript from 1.3.0 to 2.1.2 ([#10914](https://github-redirect.dependabot.com/vuejs/vue/issues/10914))
- [`9fbd416`](https://github.com/vuejs/vue/commit/9fbd416635eb3d7b32cd73b7c29f8377003c4dc8) chore: update sponsors [ci skip] ([#10896](https://github-redirect.dependabot.com/vuejs/vue/issues/10896))
- [`a974022`](https://github.com/vuejs/vue/commit/a9740225c85d8de7594a3dfcb8f18f573d4426e5) chore: update backers [ci skip] ([#10895](https://github-redirect.dependabot.com/vuejs/vue/issues/10895))
- [`6b4c0f9`](https://github.com/vuejs/vue/commit/6b4c0f9c89899f89a3ef258fb0599d78bef65664) chore: typo in comment
- [`fd0eaf9`](https://github.com/vuejs/vue/commit/fd0eaf92948bb5a4882d538362091fb287d642e3) chore: update sponsors [ci skip] ([#10841](https://github-redirect.dependabot.com/vuejs/vue/issues/10841))
- [`2c6a827`](https://github.com/vuejs/vue/commit/2c6a827b39d824f87239dc124a0e3f0895d43247) chore: update sponsors [ci skip] ([#10821](https://github-redirect.dependabot.com/vuejs/vue/issues/10821))
- [`f796ab4`](https://github.com/vuejs/vue/commit/f796ab4983f3b4066ef9a49dc654f1ee66fc3d34) chore: update sponsors [ci skip] ([#10800](https://github-redirect.dependabot.com/vuejs/vue/issues/10800))
- Additional commits viewable in [compare view](https://github.com/vuejs/vue/compare/v2.6.10...v2.6.11)
</details>
<br />

Updates `vue-template-compiler` from 2.6.10 to 2.6.11
<details>
<summary>Release notes</summary>

*Sourced from [vue-template-compiler's releases](https://github.com/vuejs/vue/releases).*

> ## v2.6.11
> ### Security Fixes
> 
> - Bump `vue-server-renderer`'s dependency of `serialize-javascript` to 2.1.2
> 
> ### Bug Fixes
> 
> * **types:** fix prop constructor type inference ([#10779](https://github-redirect.dependabot.com/vuejs/vue/issues/10779)) 4821149, closes [#10779](https://github-redirect.dependabot.com/vuejs/vue/issues/10779)
> * fix function expression regex ([#9922](https://github-redirect.dependabot.com/vuejs/vue/issues/9922)) 569b728, closes [#9922](https://github-redirect.dependabot.com/vuejs/vue/issues/9922) [#9920](https://github-redirect.dependabot.com/vuejs/vue/issues/9920)
> * **compiler:** Remove the warning for valid v-slot value ([#9917](https://github-redirect.dependabot.com/vuejs/vue/issues/9917)) 085d188, closes [#9917](https://github-redirect.dependabot.com/vuejs/vue/issues/9917)
> * **types:** fix global namespace declaration for UMD bundle ([#9912](https://github-redirect.dependabot.com/vuejs/vue/issues/9912)) ab50e8e, closes [#9912](https://github-redirect.dependabot.com/vuejs/vue/issues/9912)
</details>
<details>
<summary>Commits</summary>

- [`ec78fc8`](https://github.com/vuejs/vue/commit/ec78fc8b6d03e59da669be1adf4b4b5abf670a34) build: release 2.6.11
- [`a98048f`](https://github.com/vuejs/vue/commit/a98048fa67bb686eced6eacec156caccd33b8676) build: build 2.6.11
- [`fc41f91`](https://github.com/vuejs/vue/commit/fc41f913124b4c9cfdc9670392009774c7fc85ad) chore: update yarn.lock
- [`70429c3`](https://github.com/vuejs/vue/commit/70429c3713a497c0659fb67d61b000a3125325d2) build(deps-dev): bump serialize-javascript from 1.3.0 to 2.1.2 ([#10914](https://github-redirect.dependabot.com/vuejs/vue/issues/10914))
- [`9fbd416`](https://github.com/vuejs/vue/commit/9fbd416635eb3d7b32cd73b7c29f8377003c4dc8) chore: update sponsors [ci skip] ([#10896](https://github-redirect.dependabot.com/vuejs/vue/issues/10896))
- [`a974022`](https://github.com/vuejs/vue/commit/a9740225c85d8de7594a3dfcb8f18f573d4426e5) chore: update backers [ci skip] ([#10895](https://github-redirect.dependabot.com/vuejs/vue/issues/10895))
- [`6b4c0f9`](https://github.com/vuejs/vue/commit/6b4c0f9c89899f89a3ef258fb0599d78bef65664) chore: typo in comment
- [`fd0eaf9`](https://github.com/vuejs/vue/commit/fd0eaf92948bb5a4882d538362091fb287d642e3) chore: update sponsors [ci skip] ([#10841](https://github-redirect.dependabot.com/vuejs/vue/issues/10841))
- [`2c6a827`](https://github.com/vuejs/vue/commit/2c6a827b39d824f87239dc124a0e3f0895d43247) chore: update sponsors [ci skip] ([#10821](https://github-redirect.dependabot.com/vuejs/vue/issues/10821))
- [`f796ab4`](https://github.com/vuejs/vue/commit/f796ab4983f3b4066ef9a49dc654f1ee66fc3d34) chore: update sponsors [ci skip] ([#10800](https://github-redirect.dependabot.com/vuejs/vue/issues/10800))
- Additional commits viewable in [compare view](https://github.com/vuejs/vue/compare/v2.6.10...v2.6.11)
</details>
<br />